### PR TITLE
Add idea sharing and exploration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/contexts/AuthContext";
 import Index from "./pages/Index";
+import ExplorePage from "./pages/ExplorePage";
+import IdeaDetail from "./pages/IdeaDetail";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -19,6 +21,8 @@ const App = () => (
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
+            <Route path="/explore" element={<ExplorePage />} />
+            <Route path="/idea/:id" element={<IdeaDetail />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/api/ideas.ts
+++ b/src/api/ideas.ts
@@ -1,0 +1,63 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { Tables } from "@/integrations/supabase/types";
+
+export interface NewIdea {
+  title: string;
+  description: string;
+  category: string;
+  tags: string[];
+  file?: File | null;
+}
+
+export async function uploadFile(file: File): Promise<string> {
+  const filePath = `ideas/${Date.now()}-${file.name}`;
+  const { data, error } = await supabase.storage
+    .from("idea-files")
+    .upload(filePath, file);
+  if (error) throw error;
+  return data.path;
+}
+
+export async function createIdea(form: NewIdea): Promise<Tables<"ideas">> {
+  let image_url: string | null = null;
+  if (form.file) {
+    image_url = await uploadFile(form.file);
+  }
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { data, error } = await supabase
+    .from("ideas")
+    .insert({
+      title: form.title,
+      description: form.description,
+      category: form.category,
+      tags: form.tags,
+      image_url,
+      user_id: user?.id ?? "",
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+export async function fetchIdeas() {
+  const { data, error } = await supabase
+    .from("ideas")
+    .select("*")
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+  return data as Tables<"ideas">[];
+}
+
+export async function fetchIdea(id: string) {
+  const { data, error } = await supabase
+    .from("ideas")
+    .select("*")
+    .eq("id", id)
+    .single();
+  if (error) throw error;
+  return data as Tables<"ideas">;
+}

--- a/src/components/FeatureModal.tsx
+++ b/src/components/FeatureModal.tsx
@@ -1,0 +1,43 @@
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+import { ReactNode } from "react";
+
+interface FeatureModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  content: ReactNode;
+}
+
+export const FeatureModal = ({ isOpen, onClose, title, content }: FeatureModalProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm animate-fade-in">
+      <div className="container mx-auto px-6 py-8 h-full overflow-y-auto">
+        <div className="max-w-4xl mx-auto">
+          <Card className="glass-card p-8 animate-scale-in relative">
+            <button
+              onClick={onClose}
+              className="absolute top-4 right-4 p-2 hover:bg-white/10 rounded-full"
+            >
+              <X className="w-6 h-6" />
+            </button>
+            <h2 className="text-3xl font-bold mb-6 text-center">{title}</h2>
+            <div className="prose prose-lg max-w-none text-muted-foreground space-y-4">
+              {content}
+            </div>
+            <div className="text-center mt-8">
+              <Button variant="outline" onClick={onClose} className="px-6 py-2 rounded-full">
+                Close
+              </Button>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FeatureModal;

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -1,55 +1,173 @@
 
 import { useState } from "react";
 import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { Lightbulb, Users, Map, BookOpen, Trophy, Zap } from "lucide-react";
 import { TangibleIdeasExpander } from "./TangibleIdeasExpander";
+import FeatureModal from "./FeatureModal";
 
 const features = [
   {
     icon: Lightbulb,
     title: "Tangible Ideas Only",
-    description: "Focus on physical products that can be built, tested, and brought to market - from gadgets to sustainable packaging.",
+    description:
+      "Focus on physical products that can be built, tested, and brought to market - from gadgets to sustainable packaging.",
     gradient: "from-electric-blue to-electric-purple",
-    expandable: true
+    expandable: true,
+    modalContent: null,
   },
   {
     icon: Users,
     title: "Smart Collaboration",
-    description: "AI-powered matching system connects you with makers, designers, and builders who complement your skills.",
-    gradient: "from-electric-purple to-electric-pink"
+    description:
+      "AI-powered matching system connects you with makers, designers, and builders who complement your skills.",
+    gradient: "from-electric-purple to-electric-pink",
+    expandable: true,
+    modalContent: (
+      <>
+        <p>
+          Our AI-powered collaboration tool connects users with complementary
+          skills, matched by intent, availability, skill, and locality.
+        </p>
+        <ol className="list-decimal pl-5 space-y-1">
+          <li>Fill out a project brief</li>
+          <li>Our AI finds gaps in skills</li>
+          <li>We recommend makers near you (or virtually)</li>
+          <li>Connect, share tasks, collaborate</li>
+        </ol>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>Skill synergy</li>
+          <li>Real-time availability</li>
+          <li>Location-aware matching</li>
+          <li>Community-based ratings</li>
+        </ul>
+        <p className="italic">
+          "I met my co-builder here and now we’re launching our second
+          Kickstarter. I would’ve never found him on LinkedIn."
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 pt-2">
+          <Button className="btn-electric text-white">Start Your Collaboration Match</Button>
+          <Button variant="outline">View Community Projects</Button>
+        </div>
+      </>
+    ),
   },
   {
     icon: BookOpen,
     title: "Free Build Library",
-    description: "Access step-by-step guides, 3D models, vendor lists, and manufacturing resources crowdsourced by the community.",
-    gradient: "from-electric-green to-electric-blue"
+    description:
+      "Access step-by-step guides, 3D models, vendor lists, and manufacturing resources crowdsourced by the community.",
+    gradient: "from-electric-green to-electric-blue",
+    expandable: true,
+    modalContent: (
+      <>
+        <p>
+          Explore a growing library of open-source build guides, CAD files,
+          vendor links, and prototyping resources. Everything here is
+          community-contributed and verified.
+        </p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>3D files for components</li>
+          <li>Vendor list by geography</li>
+          <li>Material selection guides</li>
+          <li>Step-by-step build instructions</li>
+        </ul>
+        <p className="italic">Earn badges by submitting to the library.</p>
+        <div className="flex flex-col sm:flex-row gap-3 pt-2">
+          <Button className="btn-electric text-white">Browse the Library</Button>
+          <Button variant="outline">Submit a Build Guide</Button>
+        </div>
+      </>
+    ),
   },
   {
     icon: Map,
     title: "Local Maker Map",
-    description: "Find nearby maker spaces, 3D printing hubs, suppliers, and mentors to bring your ideas to life offline.",
-    gradient: "from-electric-pink to-electric-green"
+    description:
+      "Find nearby maker spaces, 3D printing hubs, suppliers, and mentors to bring your ideas to life offline.",
+    gradient: "from-electric-pink to-electric-green",
+    expandable: true,
+    modalContent: (
+      <>
+        <p>
+          Connect to your local ecosystem — from CNC shops to 3D print labs,
+          materials suppliers to mentor collectives.
+        </p>
+        <p>Enter your pin code and view mapped resources around you.</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>Reduce build times by sourcing locally</li>
+          <li>Collaborate face-to-face</li>
+          <li>Discover workshops and maker fests</li>
+        </ul>
+        <div className="flex flex-col sm:flex-row gap-3 pt-2">
+          <Button className="btn-electric text-white">Explore Your Local Map</Button>
+          <Button variant="outline">Add a New Space</Button>
+        </div>
+      </>
+    ),
   },
   {
     icon: Zap,
     title: "Execution Dashboard",
-    description: "Track your progress from prototype to product with milestones, testing feedback, and collaboration tools.",
-    gradient: "from-electric-blue to-electric-green"
+    description:
+      "Track your progress from prototype to product with milestones, testing feedback, and collaboration tools.",
+    gradient: "from-electric-blue to-electric-green",
+    expandable: true,
+    modalContent: (
+      <>
+        <p>The Execution Dashboard keeps your build on track.</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>Visual roadmap view</li>
+          <li>Shared task boards</li>
+          <li>Upload feedback from tests</li>
+          <li>Invite collaborators</li>
+        </ul>
+        <div className="flex flex-col sm:flex-row gap-3 pt-2">
+          <Button className="btn-electric text-white">Open Your Dashboard</Button>
+          <Button variant="outline">Create Your First Milestone</Button>
+        </div>
+      </>
+    ),
   },
   {
     icon: Trophy,
     title: "Gamified Community",
-    description: "Earn badges, build reputation, and showcase your expertise while helping others bring their ideas to life.",
-    gradient: "from-electric-purple to-electric-blue"
-  }
+    description:
+      "Earn badges, build reputation, and showcase your expertise while helping others bring their ideas to life.",
+    gradient: "from-electric-purple to-electric-blue",
+    expandable: true,
+    modalContent: (
+      <>
+        <p>
+          We reward participation, support, and contribution. Every time you
+          help another builder, share a design, or solve a question — you gain
+          XP, badges, and visibility.
+        </p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>Submitting a build guide = +50 XP</li>
+          <li>Commenting feedback = +10 XP</li>
+          <li>Being rated helpful = +25 XP</li>
+          <li>Hosting a build session = +100 XP</li>
+        </ul>
+        <div className="flex flex-col sm:flex-row gap-3 pt-2">
+          <Button className="btn-electric text-white">View Your XP</Button>
+          <Button variant="outline">Help Others Build</Button>
+        </div>
+      </>
+    ),
+  },
 ];
 
 const Features = () => {
   const [expanderOpen, setExpanderOpen] = useState(false);
+  const [modalFeature, setModalFeature] = useState<(typeof features)[0] | null>(null);
 
-  const handleFeatureClick = (feature: typeof features[0]) => {
-    if (feature.expandable) {
+  const handleFeatureClick = (feature: (typeof features)[0]) => {
+    if (!feature.expandable) return;
+    if (feature.title === "Tangible Ideas Only") {
       setExpanderOpen(true);
+    } else {
+      setModalFeature(feature);
     }
   };
 
@@ -128,9 +246,15 @@ const Features = () => {
       </div>
 
       {/* Expandable Modal */}
-      <TangibleIdeasExpander 
-        isOpen={expanderOpen} 
-        onClose={() => setExpanderOpen(false)} 
+      <TangibleIdeasExpander
+        isOpen={expanderOpen}
+        onClose={() => setExpanderOpen(false)}
+      />
+      <FeatureModal
+        isOpen={!!modalFeature}
+        onClose={() => setModalFeature(null)}
+        title={modalFeature?.title || ""}
+        content={modalFeature?.modalContent || null}
       />
     </section>
   );

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,8 +1,14 @@
 
 import { Button } from "@/components/ui/button";
 import { Plus, ArrowRight } from "lucide-react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import IdeaSubmissionModal from "./IdeaSubmissionModal";
 
 const Hero = () => {
+  const [shareOpen, setShareOpen] = useState(false);
+  const navigate = useNavigate();
+
   return (
     <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
       {/* Background mesh gradient */}
@@ -33,18 +39,20 @@ const Hero = () => {
           
           {/* CTA Buttons */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center pt-8">
-            <Button 
-              size="lg" 
+            <Button
+              size="lg"
               className="btn-electric text-white px-8 py-4 text-lg font-semibold rounded-full group"
+              onClick={() => setShareOpen(true)}
             >
               <Plus className="w-5 h-5 mr-2 group-hover:rotate-90 transition-transform duration-300" />
               Share Your Idea
             </Button>
             
-            <Button 
-              variant="outline" 
-              size="lg" 
+            <Button
+              variant="outline"
+              size="lg"
               className="px-8 py-4 text-lg font-semibold rounded-full glass-card hover-glow group border-white/20"
+              onClick={() => navigate('/explore')}
             >
               Explore Ideas
               <ArrowRight className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform duration-300" />
@@ -80,6 +88,7 @@ const Hero = () => {
           </div>
         </div>
       </div>
+      <IdeaSubmissionModal open={shareOpen} onOpenChange={setShareOpen} />
     </section>
   );
 };

--- a/src/components/IdeaCard.tsx
+++ b/src/components/IdeaCard.tsx
@@ -1,0 +1,39 @@
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Link } from "react-router-dom";
+import type { Tables } from "@/integrations/supabase/types";
+
+interface Props {
+  idea: Tables<"ideas">;
+}
+
+export default function IdeaCard({ idea }: Props) {
+  return (
+    <Card className="glass-card hover-glow overflow-hidden group">
+      <Link to={`/idea/${idea.id}`} className="block">
+        {idea.image_url && (
+          <div className="h-40 overflow-hidden">
+            <img
+              src={idea.image_url}
+              alt={idea.title}
+              className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
+            />
+          </div>
+        )}
+        <div className="p-4 space-y-2">
+          <h3 className="font-bold text-lg line-clamp-2">{idea.title}</h3>
+          <p className="text-muted-foreground text-sm line-clamp-2">
+            {idea.description}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {idea.tags?.slice(0, 3).map((tag) => (
+              <Badge key={tag} variant="secondary">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </Link>
+    </Card>
+  );
+}

--- a/src/components/IdeaSubmissionModal.tsx
+++ b/src/components/IdeaSubmissionModal.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { createIdea } from "@/api/ideas";
+import { toast } from "@/components/ui/sonner";
+
+interface IdeaSubmissionModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface FormValues {
+  title: string;
+  description: string;
+  category: string;
+  tags: string;
+}
+
+export default function IdeaSubmissionModal({ open, onOpenChange }: IdeaSubmissionModalProps) {
+  const navigate = useNavigate();
+  const [file, setFile] = useState<File | null>(null);
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm<FormValues>();
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      const idea = await createIdea({
+        title: values.title,
+        description: values.description,
+        category: values.category,
+        tags: values.tags
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean),
+        file,
+      });
+      toast("Idea submitted!");
+      onOpenChange(false);
+      navigate(`/idea/${idea.id}`);
+    } catch (err) {
+      console.error(err);
+      toast("Failed to submit idea");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-screen overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Share Your Idea</DialogTitle>
+          <DialogDescription>
+            Tell the community about what you want to build.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 py-2">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Idea Title</label>
+            <Input {...register("title", { required: true })} />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Short Description</label>
+            <Textarea rows={3} {...register("description", { required: true })} />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Category</label>
+            <Select onValueChange={(v) => setValue("category", v)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select category" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Gadgets">Gadgets</SelectItem>
+                <SelectItem value="Packaging">Packaging</SelectItem>
+                <SelectItem value="Tools">Tools</SelectItem>
+                <SelectItem value="Sustainability">Sustainability</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">File Upload (optional)</label>
+            <Input
+              type="file"
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Tags (comma separated)</label>
+            <Input {...register("tags")}
+              placeholder="e.g. IoT, 3D Printing" />
+          </div>
+          <DialogFooter>
+            <Button type="submit" className="btn-electric text-white">
+              Submit
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,8 +7,15 @@ interface AuthContextType {
   user: User | null;
   session: Session | null;
   loading: boolean;
-  signUp: (email: string, password: string, fullName?: string) => Promise<{ error: any }>;
-  signIn: (email: string, password: string) => Promise<{ error: any }>;
+  signUp: (
+    email: string,
+    password: string,
+    fullName?: string
+  ) => Promise<{ error: unknown }>
+  signIn: (
+    email: string,
+    password: string
+  ) => Promise<{ error: unknown }>
   signOut: () => Promise<void>;
 }
 

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -1,0 +1,28 @@
+import Navigation from "@/components/Navigation";
+import IdeaCard from "@/components/IdeaCard";
+import { useQuery } from "@tanstack/react-query";
+import { fetchIdeas } from "@/api/ideas";
+
+const ExplorePage = () => {
+  const { data: ideas, isLoading } = useQuery({
+    queryKey: ["ideas"],
+    queryFn: fetchIdeas,
+  });
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100">
+      <Navigation />
+      <main className="container mx-auto px-6 py-12 space-y-8">
+        <h1 className="text-3xl font-bold">Explore Ideas</h1>
+        {isLoading && <p>Loading...</p>}
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+          {ideas?.map((idea) => (
+            <IdeaCard key={idea.id} idea={idea} />
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default ExplorePage;

--- a/src/pages/IdeaDetail.tsx
+++ b/src/pages/IdeaDetail.tsx
@@ -1,0 +1,43 @@
+import Navigation from "@/components/Navigation";
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { fetchIdea } from "@/api/ideas";
+
+const IdeaDetail = () => {
+  const { id } = useParams<{ id: string }>();
+  const { data: idea, isLoading } = useQuery({
+    queryKey: ["idea", id],
+    queryFn: () => fetchIdea(id || ""),
+    enabled: !!id,
+  });
+
+  if (isLoading) {
+    return <p className="p-8">Loading...</p>;
+  }
+
+  if (!idea) {
+    return <p className="p-8">Idea not found</p>;
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100">
+      <Navigation />
+      <main className="container mx-auto px-6 py-12 space-y-4">
+        <h1 className="text-3xl font-bold">{idea.title}</h1>
+        {idea.image_url && (
+          <img src={idea.image_url} alt={idea.title} className="rounded-lg" />
+        )}
+        <p>{idea.description}</p>
+        <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+          {idea.tags?.map((t) => (
+            <span key={t} className="bg-muted px-2 py-1 rounded">
+              {t}
+            </span>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default IdeaDetail;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -157,5 +158,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+       plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- enable hero buttons for idea sharing and exploring
- create `IdeaSubmissionModal` for submitting ideas
- add API helpers and card components
- implement `ExplorePage` and `IdeaDetail` routes
- fix linting errors and update Tailwind config

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_6855882ea080832591c8a06f7455a50a